### PR TITLE
Change arg name of camera info for thermal to correct name

### DIFF
--- a/launch/camera/thermal_cam_pattern.launch
+++ b/launch/camera/thermal_cam_pattern.launch
@@ -9,7 +9,7 @@
     <arg name="isDarkBoard" value="false"/>
     <arg name="ns_" value="$(arg ns_)"/>
     
-    <arg name="cam_info_dir" value="$(arg cam_info_dir)"/>
+    <arg name="cam_info_filename" value="$(arg cam_info_dir)"/>
     <arg name="image_tp" value="$(arg image_tp)"/>
     <arg name="ifCompressed" value="$(arg ifCompressed)"/>
   </include>


### PR DESCRIPTION
This fix the argument name for camera intrinsic file used by thermal camera launch file so that it is correct. 

This fix Issue #20 